### PR TITLE
Fix superclass option in CIFAR-100 CNN notebook

### DIFF
--- a/mnist_cnn.ipynb
+++ b/mnist_cnn.ipynb
@@ -25,8 +25,8 @@
     "import torch.nn as nn\n",
     "import torch.nn.functional as F\n",
     "import torch.optim as optim\n",
-    "import wandb",
-    "import numpy as np"
+    "import wandb\n",
+    "import numpy as np\n"
    ]
   },
   {
@@ -76,16 +76,24 @@
     "    transforms.Normalize(mean=[0.5071, 0.4867, 0.4408], std=[0.2675, 0.2565, 0.2761])\n",
     "])\n",
     "\n",
-    "# Determine target type based on configuration\n",
-    "target_type_str = 'coarse' if USE_SUPERCLASSES else 'fine'\n",
+    "# Download and load the training and test data\n",
+    "trainset = torchvision.datasets.CIFAR100(root='./data', train=True, download=True, transform=transform)\n",
+    "testset = torchvision.datasets.CIFAR100(root='./data', train=False, download=True, transform=transform)\n",
     "\n",
-    "# Download and load the training data\n",
-    "trainset = torchvision.datasets.CIFAR100(root='./data', train=True, download=True, transform=transform, target_type=target_type_str)\n",
+    "# Older torchvision versions don't expose the 'target_type' parameter.\n",
+    "# When USE_SUPERCLASSES is True, manually map the fine labels to their\n",
+    "# corresponding coarse labels using the known mapping from the dataset.\n",
+    "if USE_SUPERCLASSES:\n",
+    "    fine_to_coarse_map = [4, 1, 14, 8, 0, 6, 7, 7, 18, 3, 3, 14, 9, 18, 7, 11, 3, 9, 7, 11,\n",
+    "                          6, 11, 5, 10, 7, 6, 13, 15, 3, 15, 0, 11, 1, 10, 12, 14, 16, 9, 11, 5,\n",
+    "                          5, 19, 8, 8, 15, 13, 14, 17, 18, 10, 16, 4, 17, 4, 2, 0, 17, 4, 18, 17,\n",
+    "                          10, 3, 2, 12, 12, 16, 12, 1, 9, 19, 2, 10, 0, 1, 16, 12, 9, 13, 15, 13,\n",
+    "                          16, 19, 2, 4, 6, 13, 1, 14, 9, 0, 5, 5, 19, 18, 10, 6, 2, 8, 11, 10]\n",
+    "    trainset.targets = [fine_to_coarse_map[t] for t in trainset.targets]\n",
+    "    testset.targets = [fine_to_coarse_map[t] for t in testset.targets]\n",
+    "\n",
     "trainloader = torch.utils.data.DataLoader(trainset, batch_size=64, shuffle=True)\n",
-    "\n",
-    "# Download and load the test data\n",
-    "testset = torchvision.datasets.CIFAR100(root='./data', train=False, download=True, transform=transform, target_type=target_type_str)\n",
-    "testloader = torch.utils.data.DataLoader(testset, batch_size=1000, shuffle=False)"
+    "testloader = torch.utils.data.DataLoader(testset, batch_size=1000, shuffle=False)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- fix syntax in initial imports cell
- rework data loading so superclass mode works on torchvision versions without `target_type`

## Testing
- `python test_notebook.py` *(fails: api_key not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68408672bf888331adf3d9da13c885bb